### PR TITLE
Added /usr/include/x86_64-linux-gnu to linux header list

### DIFF
--- a/src/Cxx.jl
+++ b/src/Cxx.jl
@@ -75,6 +75,7 @@ end
     addHeaderDir("/usr/include/c++/4.8", kind = C_System);
     addHeaderDir("/usr/include/x86_64-linux-gnu/c++/4.8/", kind = C_System);
     addHeaderDir("/usr/include", kind = C_System);
+    addHeaderDir("/usr/include/x86_64-linux-gnu", kind = C_System);
 end
 
 @windows_only begin


### PR DESCRIPTION
- Without this, I saw complaints that, e.g., `asm/errno.h` was missing
