### PR TITLE
add link to lldbHostPosix in build process

### DIFF
--- a/deps/BuildBootstrap.Makefile
+++ b/deps/BuildBootstrap.Makefile
@@ -45,7 +45,7 @@ ifeq ($(OS), WINNT)
 LLDB_LIBS += -llldbHostWindows -llldbPluginProcessWindows -lWs2_32
 endif
 ifeq ($(OS), Linux)
-LLDB_LIBS += -llldbHostLinux -llldbPluginProcessLinux -llldbPluginProcessPOSIX
+LLDB_LIBS += -llldbHostLinux -llldbPluginProcessLinux -llldbPluginProcessPOSIX -llldbHostPosix
 endif
 
 


### PR DESCRIPTION
This seems to have worked in https://github.com/Keno/Cxx.jl/issues/21, and this fix is reproducible on Debian Jessie and Ubuntu 14.04
