### PR TITLE
add link flags for libz, libbsd, and libedit

### DIFF
--- a/deps/BuildBootstrap.Makefile
+++ b/deps/BuildBootstrap.Makefile
@@ -45,7 +45,7 @@ ifeq ($(OS), WINNT)
 LLDB_LIBS += -llldbHostWindows -llldbPluginProcessWindows -lWs2_32
 endif
 ifeq ($(OS), Linux)
-LLDB_LIBS += -llldbHostLinux -llldbPluginProcessLinux -llldbPluginProcessPOSIX -llldbHostPosix
+LLDB_LIBS += -llldbHostLinux -llldbPluginProcessLinux -llldbPluginProcessPOSIX -llldbHostPosix -lz -lbsd -ledit
 endif
 
 


### PR DESCRIPTION
From:

```
steve:~/.julia/v0.4/Cxx/deps/usr/lib(sjk/newer-stdlib)$ readelf -d libcxxffi.so | grep NEEDED
 0x0000000000000001 (NEEDED)             Shared library: [libjulia.so]
 0x0000000000000001 (NEEDED)             Shared library: [libLLVM-3.6svn.so]
 0x0000000000000001 (NEEDED)             Shared library: [libz.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libedit.so.2]
 0x0000000000000001 (NEEDED)             Shared library: [libtinfo.so.5]
 0x0000000000000001 (NEEDED)             Shared library: [libdl.so.2]
 0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libstdc++.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [ld-linux-x86-64.so.2]
```
