### PR TITLE
make replpane work with julia master

### DIFF
--- a/src/CxxREPL/replpane.jl
+++ b/src/CxxREPL/replpane.jl
@@ -162,10 +162,6 @@ const cxx_keymap = {
     end
 }
 
-search_prompt, skeymap = LineEdit.setup_search_keymap(hp)
-mk = REPL.mode_keymap(main_mode)
+panel.keymap_dict = copy(main_mode.keymap_dict)
 
-b = Dict{Any,Any}[skeymap, mk, LineEdit.history_keymap, LineEdit.default_keymap, LineEdit.escape_defaults]
-panel.keymap_dict = LineEdit.keymap(b)
-
-main_mode.keymap_dict = LineEdit.keymap_merge(main_mode.keymap_dict, cxx_keymap)
+LineEdit.keymap_merge!(main_mode.keymap_dict, cxx_keymap)


### PR DESCRIPTION
Or is it some outstanding patch for julia master I am missing? (`REPL.mode_keymap` and `keymap_merge` without the bang seems to be missing)

Btw,  really interesting stuff. When this is more ready perhaps the backend part of this could be reused to make a C++ kernel for Jupyter/IPython, or perhaps a C++ "cell magic" for  the IJulia kernel.
