### PR TITLE
Update Cxx.jl

### DIFF
--- a/src/Cxx.jl
+++ b/src/Cxx.jl
@@ -285,4 +285,4 @@ include("typetranslation.jl")
 include("codegen.jl")
 include("cxxmacro.jl")
 include("cxxstr.jl")
-include("utils.jl")
+


### PR DESCRIPTION
There is no `utils.jl` file in the src folder.   This creates an error when using `Cxx.jl`.