### PR TITLE
LLVM 3.7 Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The Julia C++ Foreign Function Interface (FFI).
 
 You will need to install Julia v0.4-dev with some special options.
 
-Cxx.jl requires "staged functions" amongst other things available only in v0.4. It also requires the development version of LLVM.
+Cxx.jl requires "staged functions" amongst other things available only in v0.4. It also requires the development version of LLVM, which is currently targeting version 3.7.
 
 #### Build requirements
 

--- a/src/codegen.jl
+++ b/src/codegen.jl
@@ -650,7 +650,7 @@ function EmitExpr(ce,nE,ctce, argt, pvds, rett = Void; kwargs...)
     elseif ctce != C_NULL
         issret = true
         rt = GetExprResultType(ctce)
-        @show rt
+        #@show rt
     end
     if issret
         llvmargt = [Ptr{Uint8},llvmargt]

--- a/src/cxxmacro.jl
+++ b/src/cxxmacro.jl
@@ -94,12 +94,12 @@ function to_prefix(expr, isaddrof=false)
     elseif isexpr(expr,:&)
         return to_prefix(expr.args[1],true)
     elseif isexpr(expr,:$)
-        @show expr.args[1]
+        #@show expr.args[1]
         return (Expr(:tuple,expr.args[1],),isaddrof)
     elseif isexpr(expr,:curly)
         nns, isaddrof = to_prefix(expr.args[1],isaddrof)
         tup = Expr(:tuple)
-        @show expr
+        #@show expr
         for i = 2:length(expr.args)
             nns2, isaddrof2 = to_prefix(expr.args[i],false)
             @assert !isaddrof2

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -254,7 +254,7 @@ end
 end
 
 # Also add clang's intrinsic headers
-addHeaderDir(joinpath(basepath,"usr/lib/clang/3.6.0/include/"), kind = C_ExternCSystem)
+addHeaderDir(joinpath(basepath,"usr/lib/clang/3.7.0/include/"), kind = C_ExternCSystem)
 
 # __dso_handle is usually added by the linker when not present. However, since
 # we're not passing through a linker, we need to add it ourselves.

--- a/src/typetranslation.jl
+++ b/src/typetranslation.jl
@@ -432,7 +432,7 @@ function juliatype(t::QualType)
         elseif kind == cSChar
             return Int8
         end
-        @show kind
+        #@show kind
         dump(t)
         error("Unrecognized Integer type")
     elseif isFloatingType(t)


### PR DESCRIPTION
Updates intrinsic path for 3.7 and mentions that LLVM dev is targeting 3.7, see: https://github.com/Keno/Cxx.jl/issues/66

I also commented out a few `@show` calls that were showing up during loading.