### PR TITLE
Use iterator_range semantics

### DIFF
--- a/src/bootstrap.cpp
+++ b/src/bootstrap.cpp
@@ -733,7 +733,7 @@ public:
   }
 
   void VisitStmt(clang::Stmt *Node) {
-    for (clang::Stmt::child_range I = Node->children(); I; ++I)
+    for (clang::StmtIterator I = Node->children().begin(); I != Node->children().end(); ++I)
       if (*I)
         Visit(*I);
   }


### PR DESCRIPTION
Perhaps a change to the LLVM API?  Maybe the wrong API?  This change assumes that [children()](http://clang.llvm.org/doxygen/classclang_1_1Stmt.html#a489148e5d234a5a7f00d8b02981bcee5) returns an [llvm::iterator_range](http://llvm.org/docs/doxygen/html/classllvm_1_1iterator__range.html).  Fixes #136.