### PR TITLE
fixes for ubuntu i686 issues.

### DIFF
--- a/src/bootstrap.cpp
+++ b/src/bootstrap.cpp
@@ -875,7 +875,7 @@ DLLEXPORT void init_clang_instance(C, const char *Triple) {
     Cxx->CI->createPreprocessor(clang::TU_Prefix);
     Cxx->CI->createASTContext();
     Cxx->shadow = new llvm::Module("clangShadow",jl_LLVMContext);
-    TD = new DataLayout(tin.getDataLayoutString());
+    Cxx->shadow->setDataLayout(tin.getDataLayoutString());
     Cxx->CGM = new clang::CodeGen::CodeGenModule(
         Cxx->CI->getASTContext(),
         Cxx->CI->getHeaderSearchOpts(),

--- a/src/clangwrapper.jl
+++ b/src/clangwrapper.jl
@@ -433,7 +433,7 @@ for (rt,argt) in ((pcpp"clang::ClassTemplateSpecializationDecl",pcpp"clang::Decl
     isas = symbol(string("isa",s))
     ds = symbol(string("dcast",s))
     # @cxx llvm::isa{$rt}(t)
-    @eval $(isas)(t::$(argt)) = ccall(($(quot(isas)),libcxxffi),Int,(Ptr{Void},),t) != 0
+    @eval $(isas)(t::$(argt)) = ccall(($(quot(isas)),libcxxffi),Cint,(Ptr{Void},),t) != 0
     @eval $(ds)(t::$(argt)) = ($rt)(ccall(($(quot(ds)),libcxxffi),Ptr{Void},(Ptr{Void},),t))
 end
 
@@ -446,7 +446,7 @@ for s in (:isVoidType,:isBooleanType,:isPointerType,:isReferenceType,
     :isTemplateTypeParmType, :isArrayType)
 
     @eval ($s)(t::QualType) = ($s)(extractTypePtr(t))
-    @eval ($s)(t::pcpp"clang::Type") = ccall(($(quot(s)),libcxxffi),Int,(Ptr{Void},),t) != 0
+    @eval ($s)(t::pcpp"clang::Type") = ccall(($(quot(s)),libcxxffi),Cint,(Ptr{Void},),t) != 0
 end
 
 for (r,s) in ((pcpp"clang::CXXRecordDecl",:getPointeeCXXRecordDecl),


### PR DESCRIPTION
- Fixed an issue where initialization.jl is not able to find gcc version on i686 ubuntu.
- Fixed assertion failure / segmentation fault issues in bootstrap.cpp and clangwrapper.jl