### PR TITLE
Fixes length_error exception on Ubuntu.  Fixes #173

### DIFF
--- a/src/std.jl
+++ b/src/std.jl
@@ -3,6 +3,9 @@ import Base: bytestring
 cxxparse("""
 #include <string>
 #include <vector>
+#ifdef __linux
+#include <stdexcept>
+#endif
 """)
 
 const StdString = cxxt"std::string"


### PR DESCRIPTION
Not sure if the linux detection is necessary but don't want to break something on your mac if that is already working. Otherwise, this is now working on my Ubuntu 14.04 install.   