### PR TITLE
Fix build against llvm 3.7.1

### DIFF
--- a/deps/BuildBootstrap.Makefile
+++ b/deps/BuildBootstrap.Makefile
@@ -36,7 +36,11 @@ LLDB_LIBS = -llldbBreakpoint -llldbCommands -llldbCore -llldbInitialization \
     -llldbPluginSystemRuntimeMacOSX \
     -llldbPluginUnwindAssemblyInstEmulation -llldbPluginUnwindAssemblyX86 -llldbTarget \
     -llldbPluginInstrumentationRuntimeAddressSanitizer -llldbPluginPlatformAndroid \
-    -llldbPluginRenderScriptRuntime -llldbPluginProcessUtility \
+    -llldbPluginRenderScriptRuntime \
+    $(call exec,$(LLVM_CONFIG) --system-libs)
+
+ifeq ($(LLVM_VER),svn)
+LLDB_LIBS += -llldbPluginProcessUtility \
     -llldbPluginScriptInterpreterNone \
     -llldbPluginObjCLanguage \
     -llldbPluginCPlusPlusLanguage \
@@ -45,6 +49,10 @@ LLDB_LIBS = -llldbBreakpoint -llldbCommands -llldbCore -llldbInitialization \
     -llldbPluginOSGo -llldbPluginLanguageRuntimeGo -llldbPluginGoLanguage \
     -llldbPluginExpressionParserGo \
     $(call exec,$(LLVM_CONFIG) --system-libs)
+else
+LLDB_LIBS += -llldbPluginUtility
+endif
+
 LLDB_LIBS += -llldbPluginABIMacOSX_arm -llldbPluginABIMacOSX_arm64 -llldbPluginABIMacOSX_i386
 ifeq ($(OS), Darwin)
 LLDB_LIBS += -F/System/Library/Frameworks -F/System/Library/PrivateFrameworks -framework DebugSymbols \

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -321,7 +321,7 @@ end
 
 function addClangHeaders(C)
     # Also add clang's intrinsic headers
-    addHeaderDir(C,joinpath(JULIA_HOME,"../lib/clang/3.8.0/include/"), kind = C_ExternCSystem)
+    addHeaderDir(C,joinpath(JULIA_HOME,"../lib/clang/$(Base.libllvm_version)/include/"), kind = C_ExternCSystem)
 end
 
 function initialize_instance!(C; register_boot = true)


### PR DESCRIPTION
```
(lldb) expr jl_ExecutionEngine
(JuliaOJIT *) $0 = 0x0000000103063c00
(lldb) c
Process 14116 resuming
julia> versioninfo()
Julia Version 0.5.0-dev+2042
Commit 171b4ae* (2016-01-08 14:21 UTC)
Platform Info:
  System: Darwin (x86_64-apple-darwin15.2.0)
  CPU: Intel(R) Core(TM) i5-5287U CPU @ 2.90GHz
  WORD_SIZE: 64
  BLAS: libopenblas (USE64BITINT DYNAMIC_ARCH NO_AFFINITY Haswell)
  LAPACK: libopenblas64_
  LIBM: libopenlibm
  LLVM: libLLVM-3.7.1

julia> Pkg.test("Cxx")
INFO: Testing Cxx
foo
foo
foo
foo
foo
foo
foo
foo
foo
foo
1
2
3
4
5
6
7
8
9
10
INFO: Cxx tests passed
```