### PR TITLE
Reinterpret (with unsigned) instead of converting to allow for negative type parameters

### DIFF
--- a/src/bootstrap.cpp
+++ b/src/bootstrap.cpp
@@ -379,7 +379,7 @@ JL_DLLEXPORT void *SpecializeClass(C, clang::ClassTemplateDecl *tmplt, void **ty
     if (integralValuePresent[i] == 1) {
       clang::QualType IntT = clang::QualType::getFromOpaquePtr(types[i]);
       size_t BitWidth = Cxx->CI->getASTContext().getTypeSize(IntT);
-      llvm::APSInt Value(llvm::APInt(8,integralValues[i]));
+      llvm::APSInt Value(llvm::APInt(64,integralValues[i]));
       if (Value.getBitWidth() != BitWidth)
         Value = Value.extOrTrunc(BitWidth);
       Value.setIsSigned(IntT->isSignedIntegerOrEnumerationType());

--- a/src/typetranslation.jl
+++ b/src/typetranslation.jl
@@ -143,7 +143,7 @@ function specialize_template(C,cxxt::pcpp"clang::ClassTemplateDecl",targs)
             ts[i] = cpptype(C,t)
         elseif isa(t,Integer) || isa(t,CppEnum)
             ts[i] = cpptype(C,typeof(t))
-            integralValues[i] = convert(UInt64,isa(t,CppEnum) ? t.val : t)
+            integralValues[i] = unsigned(isa(t,CppEnum) ? t.val : t)
             integralValuesPresent[i] = 1
             bitwidths[i] = isa(t,Bool) ? 8 : sizeof(typeof(t))
         else
@@ -167,7 +167,7 @@ function specialize_template_clang(C,cxxt::pcpp"clang::ClassTemplateDecl",targs)
             ts[i] = QualType(t)
         elseif isa(t,Integer) || isa(t,CppEnum)
             ts[i] = cpptype(C, typeof(t))
-            integralValues[i] = convert(UInt64,isa(t,CppEnum) ? t.val : t)
+            integralValues[i] = unsigned(isa(t,CppEnum) ? t.val : t)
             integralValuesPresent[i] = 1
             bitwidths[i] = isa(t,Bool) ? 8 : sizeof(typeof(t))
         else
@@ -354,7 +354,7 @@ function getTemplateParameters(cxxd,quoted = false,typeargs = Dict{Int64,Void}()
         elseif kind == KindIntegral
             val = getTargAsIntegralAtIdx(targs,i)
             t = getTargIntegralTypeAtIdx(targs,i)
-            push!(args,convert(juliatype(t,quoted,typeargs),val))
+            push!(args,reinterpret(juliatype(t,quoted,typeargs),[val])[1])
         else
             error("Unhandled template argument kind ($kind)")
         end

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -301,3 +301,39 @@ end
 @test icxx"""
     std::string{$("foo bar")} == "foo bar";
 """
+
+# Negative and very large integer template parameters
+cxx"""template <uint64_t T>
+class testLargeValue
+{
+    public:
+        testLargeValue(){}
+        uint64_t getT();
+};"""
+
+cxx"""template <uint64_t T>
+uint64_t testLargeValue<T>::getT()
+{
+    return T;
+};"""
+
+cxx"""template <int T>
+class testNegativeValue
+{
+    public:
+        testNegativeValue(){}
+        int getT();
+};"""
+
+cxx"""template <int T>
+int testNegativeValue<T>::getT()
+{
+    return T;
+};"""
+
+tmp = icxx"testLargeValue<0xffffffffffffffff>();"
+@test icxx"$(tmp).getT();" == 0xffffffffffffffff
+
+tmp = icxx"testNegativeValue<-1>();"
+@test icxx"$(tmp).getT();" == -1
+


### PR DESCRIPTION
I'm not really sure if this is the right fix but it did the job for the example I worked on, i.e. wrapping matrices from the Eigen library. For arbitrary size matrices they use `-1` as type parameter value so I got a `InexactError` when `specialize_template` tried to `convert` to a `UInt64`.