### PR TITLE
Use CxxBuiltinTypes in check_args. Fixes #119 (part 2)

### DIFF
--- a/src/codegen.jl
+++ b/src/codegen.jl
@@ -433,7 +433,7 @@ function check_args(argt,f)
                 !(t <: CppFptr) && !(t <: CppMFptr) && !(t <: CppEnum) &&
                 !(t <: CppDeref) && !(t <: CppAddr) && !(t <: Ptr) &&
                 !(t <: JLCppCast) &&
-                !in(t,[Bool, UInt8, Int32, UInt32, Int64, UInt64, Float32, Float64]))
+                !isa(t, CxxBuiltinTypes))
             error("Got bad type information while compiling $f (got $t for argument $i)")
         end
     end

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -171,6 +171,10 @@ cxx""" enum { kFalse118 = 0, kTrue118 = 1 }; """
 cxx""" void foo119(char value) {} """
 @cxx foo119(UInt8(0))
 
+# UInt16 builtin (#119)
+cxx""" void foo119b(unsigned short value) {} """
+@cxx foo119b(UInt16(0))
+
 # Enums should be comparable with integers
 cxx""" enum myCoolEnum { OneValue = 1 }; """
 @assert icxx" OneValue; " == 1


### PR DESCRIPTION
Looks like #119 was actually two issues. This PR fixes the second one.

Before this PR, passing Int8, Int16, or UInt16 like so...
```
cxx""" void foo(unsigned short value) {} """
@cxx foo(UInt16(0))
```
would lead to
```
LoadError: Got bad type information while compiling Cxx.CppNNS{Tuple{:foo}} (got UInt16 for argument 1)
```

This PR adds the missing types in check_args using CxxBuiltinTypes.