### PR TITLE
alternative julia install path

### DIFF
--- a/deps/BuildBootstrap.Makefile
+++ b/deps/BuildBootstrap.Makefile
@@ -1,4 +1,4 @@
-JULIAHOME := $(subst \,/,$(JULIA_HOME))/../..
+JULIAHOME := $(subst \,/,$(BASE_JULIA_HOME))/../..
 include $(JULIAHOME)/deps/Versions.make
 include $(JULIAHOME)/Make.inc
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -11,6 +11,20 @@ if !isdefined(Base,:llvmcall)
            CXX.jl will not work!")
 end
 
-println("Tuning for julia installation at: ",JULIA_HOME)
+#in case we have specified the path to the julia installation
+#that contains the headers etc, use that
+BASE_JULIA_HOME = get(ENV, "BASE_JULIA_HOME", JULIA_HOME)
 
-run(`make -f BuildBootstrap.Makefile JULIA_HOME=$JULIA_HOME`)
+#write a simple include file with that path
+println("writing path.jl file")
+s = """
+const BASE_JULIA_HOME=\"$BASE_JULIA_HOME\"
+export BASE_JULIA_HOME
+"""
+f = open(joinpath(Pkg.dir(),"Cxx/src/path.jl"), "w")
+write(f, s)
+close(f)
+
+println("Tuning for julia installation at: ",BASE_JULIA_HOME)
+
+run(`make -f BuildBootstrap.Makefile BASE_JULIA_HOME=$BASE_JULIA_HOME`)

--- a/src/Cxx.jl
+++ b/src/Cxx.jl
@@ -139,6 +139,7 @@
 #
 __precompile__(false)
 module Cxx
+include("path.jl")
 
 using Base.Meta
 using Base: svec

--- a/src/CxxREPL/replpane.jl
+++ b/src/CxxREPL/replpane.jl
@@ -48,7 +48,7 @@ module CxxREPL
 
     # Load Clang Headers
 
-    addHeaderDir(joinpath(JULIA_HOME,"../include"))
+    addHeaderDir(joinpath(BASE_JULIA_HOME,"../include"))
 
     cxx"""
     #define __STDC_LIMIT_MACROS

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -4,7 +4,7 @@
 # adding header search directories is done in this file.
 
 # Paths
-basepath = joinpath(JULIA_HOME, "../../")
+basepath = joinpath(BASE_JULIA_HOME, "../../")
 depspath = joinpath(basepath, "deps", "srccache")
 
 # Load the Cxx.jl bootstrap library (in debug version if we're running the Julia
@@ -322,7 +322,7 @@ end
 
 function addClangHeaders(C)
     # Also add clang's intrinsic headers
-    addHeaderDir(C,joinpath(JULIA_HOME,"../lib/clang/$(Base.libllvm_version)/include/"), kind = C_ExternCSystem)
+    addHeaderDir(C,joinpath(BASE_JULIA_HOME,"../lib/clang/$(Base.libllvm_version)/include/"), kind = C_ExternCSystem)
 end
 
 function initialize_instance!(C; register_boot = true)

--- a/test/llvmincludes.jl
+++ b/test/llvmincludes.jl
@@ -1,4 +1,5 @@
-function addLLVMIncludes(C, clangheaders = true, juliainclude = joinpath(JULIA_HOME,"../include"),
+inc("../src/path.jl")
+function addLLVMIncludes(C, clangheaders = true, juliainclude = joinpath(BASE_JULIA_HOME,"../include"),
     llvmdir = joinpath(Cxx.depspath,"llvm-3.7.1"), ver = v"3.7.1")
 
     # LLVM Headers


### PR DESCRIPTION
Enable cases where julia binary and headers might be installed in different places.

The concrete case is the `jpata/ROOT.jl` package, where the julia binary resides in the Pkg directory and the `JULIA_HOME` variable points to that binary in order to be used to correctly launch any possible workers etc.

In such a case, building `Cxx.jl` fails.

Hence, `Cxx.jl` would benefit from an alternative way of configuring the julia header search paths. I propose to set it at build time via an environment variable, which would then be saved in a generated file.