### PR TITLE
First try of removing failed decls, not working at all

### DIFF
--- a/src/bootstrap.cpp
+++ b/src/bootstrap.cpp
@@ -159,6 +159,14 @@ extern "C" {
 
 extern void jl_error(const char *str);
 
+bool _debug_ast = false;
+
+// enable output of the ast
+// usage `ccall((:enable_ast_debug, Cxx.libcxxffi),Void, ())`
+JL_DLLEXPORT void enable_ast_debug() {
+  _debug_ast = true;
+}
+
 // For initialization.jl
 JL_DLLEXPORT void add_directory(C, int kind, int isFramework, const char *dirname)
 {
@@ -1106,8 +1114,16 @@ public:
   }
 
   void VisitDecl(clang::Decl *D) {
-    if (D->isInvalidDecl())
+    if (_debug_ast) {
+      std::cout << "--------------------------" << std::endl;
+      D->dump();
+      std::cout << "--------------------------" << std::endl;
+    }
+
+    // check for semantic errors
+    if (D->isInvalidDecl()) {
       FoundInvalid = true;
+    }
 
     if (isa<clang::FunctionDecl>(D) || isa<clang::ObjCMethodDecl>(D) || isa<clang::BlockDecl>(D))
       return;
@@ -1148,7 +1164,6 @@ public:
 
 };
 
-
 class JuliaCodeGenerator : public clang::ASTConsumer {
   public:
     JuliaCodeGenerator(C) : Cxx(*Cxx) {}
@@ -1164,10 +1179,23 @@ class JuliaCodeGenerator : public clang::ASTConsumer {
     bool EmitTopLevelDecl(clang::Decl *D)
     {
       Visitor.Visit(D);
-      bool HadErrors = (bool)Visitor;
-      if (!HadErrors)
+      const clang::DiagnosticsEngine& Diags = Cxx.CI->getSema().getDiagnostics();
+      bool HadErrors = ((bool) Visitor) || Diags.hasErrorOccurred() || Diags.hasFatalErrorOccurred();
+      if (!HadErrors) {
         Cxx.CGM->EmitTopLevelDecl(D);
+      } else {
+        // remove declaration if an error occured
+        clang::DeclContext* decl_ctx = D->getLexicalDeclContext();
+        if (decl_ctx->containsDecl(D)) {
+          decl_ctx->removeDecl(D);
+          std::cout << "removed decl " << D << " since an error occured" << std::endl;
+        }
+
+        // nop?
+        Cxx.CI->getSema().getASTContext().Deallocate(D);
+      }
       Visitor.reset();
+      
       return HadErrors;
     }
 


### PR DESCRIPTION
This is a first try of removing failed decls, but its not working at all. The cases that I thought would be working weren't since no error was emitted...
After a Decl of a Function was removed they still dangle arround in the Lookup tables (so lookup_name will return an invalid decl). Additionally I probably need to remove them from their Scope. To do this correctly we need something like a DeclRemovalVisitor, which would become very similar to how cling does its Transaction rewind stuff (https://github.com/vgvassilev/cling/blob/master/lib/Interpreter/TransactionUnloader.cpp). It's probably possible to adopt a lot of their code by just stripping out the Transaction stuff (which might not be a good idea since their code might not be totally stable yet and we might want transaction rewinding at a later point).