### PR TITLE
Allow for Triple and CPU to be set per compiler instance

### DIFF
--- a/src/bootstrap.cpp
+++ b/src/bootstrap.cpp
@@ -1279,7 +1279,7 @@ static void set_common_options(C)
   );
 }
 
-static void set_default_clang_options(C, bool CCompiler, const char *Triple, const char *SysRoot, Type *_T_pvalue_llvmt)
+static void set_default_clang_options(C, bool CCompiler, const char *Triple, const char *CPU, const char *SysRoot, Type *_T_pvalue_llvmt)
 {
     T_pvalue_llvmt = _T_pvalue_llvmt;
 
@@ -1313,7 +1313,7 @@ static void set_default_clang_options(C, bool CCompiler, const char *Triple, con
     Cxx->CI->getCodeGenOpts().DwarfVersion = 2;
     Cxx->CI->getCodeGenOpts().StackRealignment = 1;
     Cxx->CI->getTargetOpts().Triple = Triple == NULL ? llvm::Triple::normalize(llvm::sys::getProcessTriple()) : Triple;
-    Cxx->CI->getTargetOpts().CPU = llvm::sys::getHostCPUName ();
+    Cxx->CI->getTargetOpts().CPU = CPU == NULL ? llvm::sys::getHostCPUName() : CPU;
     StringMap< bool > ActiveFeatures;
     std::vector< std::string > Features;
     if (llvm::sys::getHostCPUFeatures(ActiveFeatures)) {
@@ -1422,11 +1422,11 @@ static void finish_clang_init(C, bool EmitPCH, const char *UsePCH) {
     assert(f_julia_type_to_llvm);
 }
 
-JL_DLLEXPORT void init_clang_instance(C, const char *Triple, const char *SysRoot, bool EmitPCH,
+JL_DLLEXPORT void init_clang_instance(C, const char *Triple, const char *CPU, const char *SysRoot, bool EmitPCH,
   bool CCompiler, const char *UsePCH, Type *_T_pvalue_llvmt) {
     Cxx->CI = new clang::CompilerInstance;
     set_common_options(Cxx);
-    set_default_clang_options(Cxx, CCompiler, Triple, SysRoot, _T_pvalue_llvmt);
+    set_default_clang_options(Cxx, CCompiler, Triple, CPU, SysRoot, _T_pvalue_llvmt);
     finish_clang_init(Cxx, EmitPCH, UsePCH);
 }
 

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -21,13 +21,13 @@ function init_libcxxffi()
 end
 init_libcxxffi()
 
-function setup_instance(UsePCH = C_NULL; makeCCompiler=false)
+function setup_instance(UsePCH = C_NULL; makeCCompiler=false, target = C_NULL, CPU = C_NULL)
     x = Array(ClangCompiler,1)
     sysroot = @static is_apple() ? strip(readstring(`xcodebuild -version -sdk macosx Path`)) : C_NULL
     EmitPCH = true
     ccall((:init_clang_instance,libcxxffi),Void,
-        (Ptr{Void},Ptr{UInt8},Ptr{UInt8},Bool,Bool,Ptr{UInt8},Ptr{Void}),
-        x,C_NULL,sysroot,EmitPCH,makeCCompiler,UsePCH,julia_to_llvm(Any))
+        (Ptr{Void},Ptr{UInt8},Ptr{UInt8},Ptr{UInt8},Bool,Bool,Ptr{UInt8},Ptr{Void}),
+        x,target,CPU,sysroot,EmitPCH,makeCCompiler,UsePCH,julia_to_llvm(Any))
     x[1]
 end
 
@@ -359,8 +359,8 @@ function __init__()
     unsafe_store!(callback, cfunction(process_cxx_exception,Union{},Tuple{UInt64,Ptr{Void}}))
 end
 
-function new_clang_instance(register_boot = true, makeCCompiler = false)
-    C = setup_instance(makeCCompiler = makeCCompiler)
+function new_clang_instance(register_boot = true, makeCCompiler = false; target = C_NULL, CPU = C_NULL)
+    C = setup_instance(makeCCompiler = makeCCompiler, target = target, CPU = CPU)
     initialize_instance!(C; register_boot = register_boot)
     push!(active_instances, C)
     CxxInstance{length(active_instances)}()


### PR DESCRIPTION
This is the minimal change necessary to freely choose target triple and cpu.

`CI = Cxx.new_clang_instance(false, false, target = "nvptx64-nvidia-cuda", CPU = "sm_35")`

I am running into the problem that I need to set specific options to TargetOpts and and CodeGenOpts.
