### PR TITLE
[RFC] Configure Cuda options if targets starts with nvptx

### DIFF
--- a/src/bootstrap.cpp
+++ b/src/bootstrap.cpp
@@ -1311,7 +1311,6 @@ static void set_default_clang_options(C, bool CCompiler, const char *Triple, con
     if (isnvptx) {
         Cxx->CI->getLangOpts().CUDA = 1;
         Cxx->CI->getLangOpts().CUDAIsDevice = 1;
-        Cxx->CI->getLangOpts().CPlusPlus14 = 0;
         Cxx->CI->getLangOpts().DeclSpecKeyword = 1;
 #ifdef LLVM38
         Cxx->CI->getLangOpts().CUDAAllowHostCallsFromHostDevice = 1;


### PR DESCRIPTION
```julia
CI = Cxx.new_clang_instance(false, false, target = "nvptx64-nvidia-c    uda", CPU = "sm_35")
addHeaderDir(CI, "/opt/cuda/include", kind = C_System)

# Needs at least LLVM_VER=3.8 
cxxinclude(CI, "__clang_cuda_runtime_wrapper.h")
```

I think I still miss some options, but this gets me 95% of the way.