### PR TITLE
Only enable the special CUDA options on LLVM 3.8

### DIFF
--- a/src/bootstrap.cpp
+++ b/src/bootstrap.cpp
@@ -1321,9 +1321,10 @@ static void set_default_clang_options(C, bool CCompiler, const char *Triple, con
         Cxx->CI->getLangOpts().CUDA = 1;
         Cxx->CI->getLangOpts().CUDAIsDevice = 1;
         Cxx->CI->getLangOpts().DeclSpecKeyword = 1;
-#ifdef LLVM38
+#if defined(LLVM38) && !defined(LLVM39)
         Cxx->CI->getLangOpts().CUDAAllowHostCallsFromHostDevice = 1;
         Cxx->CI->getLangOpts().CUDATargetOverloads = 1;
+        Cxx->CI->getLangOpts().CUDADisableTargetCallChecks = 1;
 #endif
     }
 


### PR DESCRIPTION
I don't have a working `0.5` right now, so couldn't test it.