### PR TITLE
Fix typo in clangwrapper.jl that triggers an LLVM assersion

### DIFF
--- a/src/clangwrapper.jl
+++ b/src/clangwrapper.jl
@@ -732,7 +732,7 @@ function SetVarDeclInit(D::pcpp"clang::VarDecl", init)
 end
 
 function SetConstexpr(VD::pcpp"clang::VarDecl")
-    ccall((:SetVarDeclInit, libcxxffi), Void, (Ptr{Void},), VD)
+    ccall((:SetConstexpr, libcxxffi), Void, (Ptr{Void},), VD)
 end
 
 function isCCompiler(C)


### PR DESCRIPTION
when embedding a `Val{n}` as a constant expression. Not sure why the LLVM assertion happens only on REPL for me, not in Pkg.test("Cxx"), but the change does fix the issue.

```
julia> cxx"""
       template <int i> class Template246 {
       public:
           int getI() { return i; }
       };
       """
true


julia> icxx"Template246<$(Val{5})>().getI();" == 5
Assertion failed: (isa<X>(Val) && "cast<Ty>() argument of incompatible type!"), function cast, file /Users/ryuyamamoto/julia/deps/srccache/llvm-3.7.1/include/llvm/Support/Casting.h, line 237.


signal (4): Illegal instruction: 4
while loading no file, in expression starting on line 0
abort at /Users/ryuyamamoto/julia/usr/lib//libLLVM-3.7.dylib (unknown line)
__assert_rtn at /Users/ryuyamamoto/julia/usr/lib//libLLVM-3.7.dylib (unknown line)
_ZNK5clang7VarDecl14checkInitIsICEEv at /Users/ryuyamamoto/.julia/v0.6/Cxx/deps/usr/lib/libcxxffi.dylib (unknown line)
_ZL23DoMarkVarDeclReferencedRN5clang4SemaENS_14SourceLocationEPNS_7VarDeclEPNS_4ExprE at /Users/ryuyamamoto/.julia/v0.6/Cxx/deps/usr/lib/libcxxffi.dylib (unknown line)
_ZN5clang4Sema16BuildDeclRefExprEPNS_9ValueDeclENS_8QualTypeENS_13ExprValueKindERKNS_19DeclarationNameInfoEPKNS_12CXXScopeSpecEPNS_9NamedDeclEPKNS_24TemplateArgumentListInfoE at /Users/ryuyamamoto/.julia/v0.6/Cxx
/deps/usr/lib/libcxxffi.dylib (unknown line)
_ZN5clang4Sema24BuildDeclarationNameExprERKNS_12CXXScopeSpecERKNS_19DeclarationNameInfoEPNS_9NamedDeclES8_PKNS_24TemplateArgumentListInfoEb at /Users/ryuyamamoto/.julia/v0.6/Cxx/deps/usr/lib/libcxxffi.dylib (unkn
own line)
_ZN5clang4Sema24BuildDeclarationNameExprERKNS_12CXXScopeSpecERNS_12LookupResultEbb at /Users/ryuyamamoto/.julia/v0.6/Cxx/deps/usr/lib/libcxxffi.dylib (unknown line)
_ZN5clang4Sema12ClassifyNameEPNS_5ScopeERNS_12CXXScopeSpecERPNS_14IdentifierInfoENS_14SourceLocationERKNS_5TokenEbNSt3__110unique_ptrINS_27CorrectionCandidateCallbackENSC_14default_deleteISE_EEEE at /Users/ryuyam
amoto/.julia/v0.6/Cxx/deps/usr/lib/libcxxffi.dylib (unknown line)
_ZN5clang6Parser15TryAnnotateNameEbNSt3__110unique_ptrINS_27CorrectionCandidateCallbackENS1_14default_deleteIS3_EEEE at /Users/ryuyamamoto/.julia/v0.6/Cxx/deps/usr/lib/libcxxffi.dylib (unknown line)
_ZN5clang6Parser25isCXXDeclarationSpecifierENS0_8TPResultEPb at /Users/ryuyamamoto/.julia/v0.6/Cxx/deps/usr/lib/libcxxffi.dylib (unknown line)
_ZN5clang6Parser11isCXXTypeIdENS0_25TentativeCXXTypeIdContextERb at /Users/ryuyamamoto/.julia/v0.6/Cxx/deps/usr/lib/libcxxffi.dylib (unknown line)
_ZN5clang6Parser21ParseTemplateArgumentEv at /Users/ryuyamamoto/.julia/v0.6/Cxx/deps/usr/lib/libcxxffi.dylib (unknown line)
_ZN5clang6Parser25ParseTemplateArgumentListERN4llvm11SmallVectorINS_22ParsedTemplateArgumentELj16EEE at /Users/ryuyamamoto/.julia/v0.6/Cxx/deps/usr/lib/libcxxffi.dylib (unknown line)
_ZN5clang6Parser32ParseTemplateIdAfterTemplateNameENS_9OpaquePtrINS_12TemplateNameEEENS_14SourceLocationERKNS_12CXXScopeSpecEbRS4_RN4llvm11SmallVectorINS_22ParsedTemplateArgumentELj16EEES8_ at /Users/ryuyamamoto/
.julia/v0.6/Cxx/deps/usr/lib/libcxxffi.dylib (unknown line)
_ZN5clang6Parser23AnnotateTemplateIdTokenENS_9OpaquePtrINS_12TemplateNameEEENS_16TemplateNameKindERNS_12CXXScopeSpecENS_14SourceLocationERNS_13UnqualifiedIdEb at /Users/ryuyamamoto/.julia/v0.6/Cxx/deps/usr/lib/li
bcxxffi.dylib (unknown line)
_ZN5clang6Parser30ParseOptionalCXXScopeSpecifierERNS_12CXXScopeSpecENS_9OpaquePtrINS_8QualTypeEEEbPbbPPNS_14IdentifierInfoE at /Users/ryuyamamoto/.julia/v0.6/Cxx/deps/usr/lib/libcxxffi.dylib (unknown line)
_ZN5clang6Parser15TryAnnotateNameEbNSt3__110unique_ptrINS_27CorrectionCandidateCallbackENS1_14default_deleteIS3_EEEE at /Users/ryuyamamoto/.julia/v0.6/Cxx/deps/usr/lib/libcxxffi.dylib (unknown line)
_ZN5clang6Parser42ParseStatementOrDeclarationAfterAttributesERN4llvm11SmallVectorIPNS_4StmtELj32EEEbPNS_14SourceLocationERNS0_25ParsedAttributesWithRangeE at /Users/ryuyamamoto/.julia/v0.6/Cxx/deps/usr/lib/libcxx
ffi.dylib (unknown line)
_ZN5clang6Parser27ParseStatementOrDeclarationERN4llvm11SmallVectorIPNS_4StmtELj32EEEbPNS_14SourceLocationE at /Users/ryuyamamoto/.julia/v0.6/Cxx/deps/usr/lib/libcxxffi.dylib (unknown line)
_ZN5clang6Parser26ParseCompoundStatementBodyEb at /Users/ryuyamamoto/.julia/v0.6/Cxx/deps/usr/lib/libcxxffi.dylib (unknown line)
ParseFunctionStatementBody at /Users/ryuyamamoto/.julia/v0.6/Cxx/deps/usr/lib/libcxxffi.dylib (unknown line)
ParseFunctionStatementBody at /Users/ryuyamamoto/.julia/v0.6/Cxx/src/cxxstr.jl:213
#CreateFunctionWithBody#50 at /Users/ryuyamamoto/.julia/v0.6/Cxx/src/cxxstr.jl:326
jl_call_method_internal at /Users/ryuyamamoto/julia/src/./julia_internal.h:189 [inlined]
jl_apply_generic at /Users/ryuyamamoto/julia/src/gf.c:1931
jl_apply at /Users/ryuyamamoto/julia/src/./julia.h:1392 [inlined]
jl_f__apply at /Users/ryuyamamoto/julia/src/builtins.c:547
#CreateFunctionWithBody at ./<missing>:0                                                                                                                                                                  [737/1933]
jl_call_method_internal at /Users/ryuyamamoto/julia/src/./julia_internal.h:189 [inlined]
jl_apply_generic at /Users/ryuyamamoto/julia/src/gf.c:1931
jl_apply at /Users/ryuyamamoto/julia/src/./julia.h:1392 [inlined]
jl_f__apply at /Users/ryuyamamoto/julia/src/builtins.c:547
cxxstr_impl at /Users/ryuyamamoto/.julia/v0.6/Cxx/src/cxxstr.jl:347
jl_call_staged at /Users/ryuyamamoto/julia/src/alloc.c:457 [inlined]
jl_instantiate_staged at /Users/ryuyamamoto/julia/src/alloc.c:495
jl_specializations_get_linfo at /Users/ryuyamamoto/julia/src/gf.c:131
cache_method at /Users/ryuyamamoto/julia/src/gf.c:761
jl_mt_assoc_by_type at /Users/ryuyamamoto/julia/src/gf.c:833
jl_apply_generic at /Users/ryuyamamoto/julia/src/gf.c:1913
do_call at /Users/ryuyamamoto/julia/src/interpreter.c:66
eval at /Users/ryuyamamoto/julia/src/interpreter.c:205
do_call at /Users/ryuyamamoto/julia/src/interpreter.c:65
eval at /Users/ryuyamamoto/julia/src/interpreter.c:205
jl_toplevel_eval_flex at /Users/ryuyamamoto/julia/src/toplevel.c:619
jl_toplevel_eval_in_warn at /Users/ryuyamamoto/julia/src/builtins.c:590
eval at ./boot.jl:234
eval at ./REPL.jl:3
unknown function (ip: 0x317bb41d4)
jl_call_method_internal at /Users/ryuyamamoto/julia/src/./julia_internal.h:189 [inlined]
jl_apply_generic at /Users/ryuyamamoto/julia/src/gf.c:1931
eval_user_input at ./REPL.jl:66
unknown function (ip: 0x317bb4074)
jl_call_method_internal at /Users/ryuyamamoto/julia/src/./julia_internal.h:189 [inlined]
jl_apply_generic at /Users/ryuyamamoto/julia/src/gf.c:1931
macro expansion at ./REPL.jl:97 [inlined]
#3 at ./event.jl:68
unknown function (ip: 0x317ba20ca)
jl_call_method_internal at /Users/ryuyamamoto/julia/src/./julia_internal.h:189 [inlined]
jl_apply_generic at /Users/ryuyamamoto/julia/src/gf.c:1931
jl_apply at /Users/ryuyamamoto/julia/src/./julia.h:1392 [inlined]
start_task at /Users/ryuyamamoto/julia/src/task.c:259
Allocations: 7681072 (Pool: 7679685; Big: 1387); GC: 13


signal (6): Abort trap: 6

```

```
julia> versioninfo()
Julia Version 0.6.0-dev.446
Commit cd94c99* (2016-09-01 13:15 UTC)
Platform Info:
  System: Darwin (x86_64-apple-darwin15.5.0)
  CPU: Intel(R) Core(TM) i5-4258U CPU @ 2.40GHz
  WORD_SIZE: 64
  BLAS: libopenblas (USE64BITINT DYNAMIC_ARCH NO_AFFINITY Haswell)
  LAPACK: libopenblas64_
  LIBM: libopenlibm
  LLVM: libLLVM-3.7.1 (ORCJIT, haswell)
```