### PR TITLE
fix deprecations for v0.6

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -26,7 +26,7 @@ println("Tuning for julia installation at $BASE_JULIA_BIN with sources possibly 
 llvm_path = is_apple() ? "libLLVM" : "libLLVM-$(Base.libllvm_version)"
 
 llvm_lib_path = Libdl.dlpath(llvm_path)
-old_cxx_abi = searchindex(open(read, llvm_lib_path),"_ZN4llvm3sys16getProcessTripleEv".data,0) != 0
+old_cxx_abi = searchindex(read(llvm_lib_path), Vector{UInt8}("_ZN4llvm3sys16getProcessTripleEv"),0) != 0
 old_cxx_abi && (ENV["OLD_CXX_ABI"] = "1")
 
 llvm_config_path = joinpath(BASE_JULIA_BIN,"..","tools","llvm-config")

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -24,22 +24,22 @@ init_libcxxffi()
 
 function setup_instance(UsePCH = C_NULL; makeCCompiler=false, target = C_NULL, CPU = C_NULL,
         useDefaultCxxABI=true)
-    x = Array(ClangCompiler,1)
+    x = Ref{ClangCompiler}()
     sysroot = @static is_apple() ? strip(readstring(`xcodebuild -version -sdk macosx Path`)) : C_NULL
     EmitPCH = true
     ccall((:init_clang_instance,libcxxffi),Void,
         (Ptr{Void},Ptr{UInt8},Ptr{UInt8},Ptr{UInt8},Bool,Bool,Ptr{UInt8},Ptr{Void}),
         x,target,CPU,sysroot,EmitPCH,makeCCompiler,UsePCH,julia_to_llvm(Any))
     useDefaultCxxABI && ccall((:apply_default_abi, libcxxffi),
-        Void, (Ptr{ClangCompiler},), &x[1])
-    x[1]
+        Void, (Ptr{ClangCompiler},), &x[])
+    x[]
 end
 
 function setup_instance_from_inovcation(invocation)
-    x = Array(ClangCompiler,1)
+    x = Ref{ClangCompiler}()
     ccall((:init_clang_instance_from_invocation,libcxxffi),Void,
         (Ptr{Void},Ptr{Void}), x, invocation)
-    x[1]
+    x[]
 end
 
 # Running global constructors

--- a/src/show.jl
+++ b/src/show.jl
@@ -1,4 +1,3 @@
-Base.bytestring(str::vcpp"llvm::StringRef") = Cxx.unsafe_string(icxx"$str.data();",icxx"$str.size();")
 typename(QT) = Cxx.getTypeNameAsString(QT)
 function typename{T<:Cxx.CxxQualType}(::Type{T})
     C = Cxx.instance(Cxx.__default_compiler__)
@@ -27,7 +26,7 @@ end
             if (field->getAccess() != clang::AS_public)
                 continue;
             $:(begin
-                fieldname = bytestring(icxx"return field->getName();")
+                fieldname = String(icxx"return field->getName();")
                 showexpr = Expr(:macrocall,Symbol("@icxx_str"),"
                     auto &r = \$x.$fieldname;
                     return r;

--- a/src/std.jl
+++ b/src/std.jl
@@ -18,7 +18,8 @@ String(str::Union{StdString,StdStringR}) = unsafe_string(str)
 
 import Base: showerror
 import Cxx: CppValue
-for T in Cxx.CxxBuiltinTypes.types
+
+for T in Base.uniontypes(Cxx.CxxBuiltinTypes)
     @eval @exception function showerror(io::IO, e::$(T.parameters[1]))
         print(io, e)
     end
@@ -26,7 +27,7 @@ end
 @exception function showerror(io::IO, e::cxxt"std::length_error&")
     try
         @show e
-        print(io, bytestring(icxx"$e.what();"))
+        print(io, String(icxx"$e.what();"))
     catch w
         @show w
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -43,7 +43,7 @@ macro icxxdebug_str(str,args...)
     if isempty(args)
         args = (Symbol(""),1,1)
     end
-    push!(sourcebuffers,(takebuf_string(sourcebuf),args...))
+    push!(sourcebuffers,(String(take!(sourcebuf)),args...))
     id = length(sourcebuffers)
     esc(build_icxx_expr(id, exprs, isexprs, Any[], compiler, dumpast_impl))
 end


### PR DESCRIPTION
I wanted to update CUDAnativelib for the upcoming release and for that I need Cxx.jl

This currently seqfaults on v0.6 and didn't have time yet to investigate it.