### PR TITLE
Fix show error on v0.6: use `unsafe_string` instead of `bytestring`

### DIFF
--- a/src/exceptions.jl
+++ b/src/exceptions.jl
@@ -76,7 +76,7 @@ function process_cxx_exception(code::UInt64, e::Ptr{Void})
         offset = Base.fieldoffset(LibCxxException,length(LibCxxException.types))
         cxxe = Ptr{LibCxxException}(e - offset)
         T = unsafe_load(cxxe).exceptionType
-        throw(CxxException{Symbol(bytestring(icxx"$T->name();"))}(cxxe))
+        throw(CxxException{Symbol(unsafe_string(icxx"$T->name();"))}(cxxe))
     elseif (code & get_vendor_and_language) == libstdcxx_class
         # This is a libstdc++ exception
         offset = Base.fieldoffset(LibStdCxxException,length(LibStdCxxException.types))


### PR DESCRIPTION
This also fixes the deprecation warning on v0.5

Now that tests are passing locally both on v0.5 and v0.6 without deprecation warnings.