### PR TITLE
Add badges to README, submit coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.jl.cov
+*.jl.*.cov
+*.jl.mem

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,8 @@ script:
     - mv $THE_PKG_DIR/Cxx-cache/deps/src $THE_PKG_DIR/Cxx/deps/src || true
     - mv $THE_PKG_DIR/Cxx-cache/deps/build $THE_PKG_DIR/Cxx/deps/build || true
     - if [ ! -f $HOME/early_abort ]; then PREBUILT_CI_BINARIES=1 julia -e 'Pkg.build("Cxx")' || false; fi
-    - if [ ! -f $HOME/early_abort ]; then julia -e 'Pkg.test("Cxx")' || false; fi
+    - if [ ! -f $HOME/early_abort ]; then julia -e 'Pkg.test("Cxx"; coverage=true)' || false; fi
+after_success:
+    - julia -e 'cd(Pkg.dir("Cxx")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 ## Cxx.jl
 
+[![Build Status](https://travis-ci.org/Keno/Cxx.jl.svg?branch=master)](https://travis-ci.org/Keno/Cxx.jl)
+[![codecov.io](http://codecov.io/github/Keno/Cxx.jl/coverage.svg?branch=master)](http://codecov.io/github/Keno/Cxx.jl?branch=master)
+
 The Julia C++ Foreign Function Interface (FFI) and REPL.
 
 ![REPL Screenshot](doc/screenshot.png "C++ REPL Screenshot")

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false


### PR DESCRIPTION
This PR adds status badges for ~~PkgEval,~~ Travis, and ~~Coveralls~~ Codecov to the README and sets up Travis to submit coverage info. ~~Note that you'll have to manually enable the Coveralls service for this repo at https://coveralls.io.~~ I've also added the standard gitignore file that ignores coverage-related files.