### PR TITLE
Improvements in looking for C++ headers on apple systems

### DIFF
--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -24,7 +24,7 @@ init_libcxxffi()
 function setup_instance(PCHBuffer = []; makeCCompiler=false, target = C_NULL, CPU = C_NULL,
         useDefaultCxxABI=true, PCHTime = Base.Libc.TmStruct())
     x = Array{ClangCompiler}(1)
-    sysroot = @static isapple() ? strip(read(`xcodebuild -version -sdk macosx Path`, String)) : C_NULL
+    sysroot = @static isapple() ? strip(read(`xcrun --sdk macosx --show-sdk-path`, String)) : C_NULL
     EmitPCH = true
     PCHPtr = C_NULL
     PCHSize = 0
@@ -214,8 +214,10 @@ nostdcxx = haskey(ENV,"CXXJL_NOSTDCXX")
 
 # On OS X, we just use the libc++ headers that ship with XCode
 @static if isapple() function collectStdHeaders!(headers)
-    xcode_path =
-        "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/"
+    xcode_path = strip(read(`xcode-select --print-path`, String))
+    contains(xcode_path, "Xcode.app") && (xcode_path *= "/Toolchains/XcodeDefault.xctoolchain")
+    xcode_path *= "/"
+
     didfind = false
     for path in ("usr/lib/c++/v1/","usr/include/c++/v1")
         if isdir(joinpath(xcode_path,path))


### PR DESCRIPTION
Rely on `xcrun` and `xcode-select` commands instead of `xcodebuild` (available only with a complete Xcode installation) and hardcoding paths. Now C++ headers are found even only with the Apple Command Line Tools installed, see issue #363. Changes should be propagated to all the other tags. Credits to @EmileParolin for suggesting `xcrun`.