### PR TITLE
Support using cxxt with TemplateSpecializationType

### DIFF
--- a/src/bootstrap.cpp
+++ b/src/bootstrap.cpp
@@ -2206,6 +2206,11 @@ JL_DLLEXPORT void *getTargIntegralTypeAtIdx(clang::TemplateArgumentList *targs, 
     return getTargIntegralType(&targs->get(i));
 }
 
+JL_DLLEXPORT void *getTSTTargIntegralTypeAtIdx(clang::TemplateSpecializationType *TST, size_t i)
+{
+    return getTargIntegralType(&TST->getArg(i));
+}
+
 JL_DLLEXPORT int getTargKind(const clang::TemplateArgument *targ)
 {
     return targ->getKind();
@@ -2234,6 +2239,11 @@ JL_DLLEXPORT void *getTargPackAtIdxTargAtIdx(clang::TemplateArgumentList *targs,
 JL_DLLEXPORT int64_t getTargAsIntegralAtIdx(clang::TemplateArgumentList *targs, size_t i)
 {
     return targs->get(i).getAsIntegral().getSExtValue();
+}
+
+JL_DLLEXPORT int64_t getTSTTargAsIntegralAtIdx(clang::TemplateSpecializationType *TST, size_t i)
+{
+    return TST->getArg(i).getAsIntegral().getSExtValue();
 }
 
 void *getTargPackBegin(clang::TemplateArgument *targ)

--- a/src/clangwrapper.jl
+++ b/src/clangwrapper.jl
@@ -191,8 +191,15 @@ getTargKind(targ) =
 getTargAsIntegralAtIdx(targs::rcpp"clang::TemplateArgumentList", i) =
     ccall((:getTargAsIntegralAtIdx,libcxxffi),Int64,(Ptr{Void},Csize_t),targs,i)
 
-getTargIntegralTypeAtIdx(targs, i) =
+getTargAsIntegralAtIdx(targs::pcpp"clang::TemplateSpecializationType", i) =
+   ccall((:getTSTTargAsIntegralAtIdx,libcxxffi),Int64,(Ptr{Void},Csize_t),targs,i)
+
+getTargIntegralTypeAtIdx(targs::Union{rcpp"clang::TemplateArgumentList",
+                                        pcpp"clang::TemplateArgumentList"}, i) =
     QualType(ccall((:getTargIntegralTypeAtIdx,libcxxffi),Ptr{Void},(Ptr{Void},Csize_t),targs,i))
+
+getTargIntegralTypeAtIdx(targs::pcpp"clang::TemplateSpecializationType", i) =
+    QualType(ccall((:getTSTTargIntegralTypeAtIdx,libcxxffi),Ptr{Void},(Ptr{Void},Csize_t),targs,i))
 
 getTargPackAtIdxSize(targs, i) =
     ccall((:getTargPackAtIdxSize, libcxxffi), Csize_t, (Ptr{Void}, Csize_t), targs, i)

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -445,3 +445,12 @@ public:
 };
 """
 @assert icxx"privfoo{}.bar;"p == 1
+
+# Test TemplateSpecializationType for cxxt
+cxx"""
+    template<typename T, int R, int C=5>
+    struct LikeEigen { T val = 5.0; };
+"""
+
+const LikeEigen{T} = cxxt"LikeEigen<$T,2>"
+@test icxx"$(LikeEigen{Float64})().val" == 5.0


### PR DESCRIPTION
This allows defining a type using `cxxt` when the C++ template resolves to a `TemplateSpecializationType`, which seems to happen when there are default arguments.