### PR TITLE
[WIP, don't merge] Non-type parameters in cxxt

### DIFF
--- a/src/bootstrap.cpp
+++ b/src/bootstrap.cpp
@@ -2206,6 +2206,11 @@ JL_DLLEXPORT void *getTargIntegralTypeAtIdx(clang::TemplateArgumentList *targs, 
     return getTargIntegralType(&targs->get(i));
 }
 
+JL_DLLEXPORT void *getTSTTargIntegralTypeAtIdx(clang::TemplateSpecializationType *TST, size_t i)
+{
+    return getTargIntegralType(&TST->getArg(i));
+}
+
 JL_DLLEXPORT int getTargKind(const clang::TemplateArgument *targ)
 {
     return targ->getKind();
@@ -2234,6 +2239,11 @@ JL_DLLEXPORT void *getTargPackAtIdxTargAtIdx(clang::TemplateArgumentList *targs,
 JL_DLLEXPORT int64_t getTargAsIntegralAtIdx(clang::TemplateArgumentList *targs, size_t i)
 {
     return targs->get(i).getAsIntegral().getSExtValue();
+}
+
+JL_DLLEXPORT int64_t getTSTTargAsIntegralAtIdx(clang::TemplateSpecializationType *TST, size_t i)
+{
+    return TST->getArg(i).getAsIntegral().getSExtValue();
 }
 
 void *getTargPackBegin(clang::TemplateArgument *targ)

--- a/src/bootstrap.cpp
+++ b/src/bootstrap.cpp
@@ -2213,6 +2213,9 @@ JL_DLLEXPORT void *getTSTTargIntegralTypeAtIdx(clang::TemplateSpecializationType
 
 JL_DLLEXPORT int getTargKind(const clang::TemplateArgument *targ)
 {
+    std::cerr << "dumping targ:" << std::endl;
+    targ->dump();
+    std::cerr << std::endl;
     return targ->getKind();
 }
 
@@ -2802,6 +2805,39 @@ JL_DLLEXPORT void *ActOnTypeParameterParserScope(C, char *Name, unsigned Positio
                                     clang::SourceLocation(), DefaultArg);
   //sema.ActOnPopScope(clang::SourceLocation(),&S);
   return ret;
+}
+
+JL_DLLEXPORT void *ActOnNonTypeParameterParserScope(C, char *Name, unsigned Position)
+{
+  // ActOnNonTypeTemplateParameter (Scope *S, Declarator &D, unsigned Depth, unsigned Position, SourceLocation EqualLoc, Expr *DefaultArg)
+  // ActOnTypeParameter (Scope *S, bool Typename, SourceLocation EllipsisLoc, SourceLocation KeyLoc, IdentifierInfo *ParamName, SourceLocation ParamNameLoc, unsigned Depth, unsigned Position, SourceLocation EqualLoc, ParsedType DefaultArg)
+  clang::Sema &sema = Cxx->CI->getSema();
+  clang::Preprocessor &PP = Cxx->Parser->getPreprocessor();
+
+  // clang::DeclSpec DS(Cxx->Parser->getAttrFactory());
+  // unsigned DiagID = 0;
+  // const char* PrevSpec = "";
+  // DS.SetTypeSpecType(clang::DeclSpec::TST_int, clang::SourceLocation(), PrevSpec, DiagID, Cxx->CI->getASTContext().getPrintingPolicy());
+  // std::cout << clang::DeclSpec::getSpecifierName(DS.getTypeSpecType(),Cxx->CI->getASTContext().getPrintingPolicy()) << std::endl;
+  // clang::Declarator D(DS, clang::Declarator::TemplateParamContext);
+  // D.getName().setIdentifier(PP.getIdentifierInfo(Name),clang::SourceLocation());
+
+  // void *ret = (void*)sema.ActOnNonTypeTemplateParameter(Cxx->Parser->getCurScope(), D, 0, Position, clang::SourceLocation(), nullptr);
+  // return ret;
+
+  clang::QualType QT = sema.getASTContext().IntTy;
+  
+  clang::NonTypeTemplateParmDecl* Param = clang::NonTypeTemplateParmDecl::Create(sema.getASTContext(),
+                                         sema.getASTContext().getTranslationUnitDecl(),
+                                         clang::SourceLocation(),
+                                         clang::SourceLocation(),
+                                         0, Position, PP.getIdentifierInfo(Name),
+                                         QT, false, sema.getASTContext().getTrivialTypeSourceInfo(QT));
+
+  Param->setAccess(clang::AS_public);
+  Cxx->Parser->getCurScope()->AddDecl(Param);
+  sema.IdResolver.AddDecl(Param);
+  return (void*)Param;
 }
 
 JL_DLLEXPORT void ExitParserScope(C)

--- a/src/clangwrapper.jl
+++ b/src/clangwrapper.jl
@@ -191,8 +191,15 @@ getTargKind(targ) =
 getTargAsIntegralAtIdx(targs::rcpp"clang::TemplateArgumentList", i) =
     ccall((:getTargAsIntegralAtIdx,libcxxffi),Int64,(Ptr{Void},Csize_t),targs,i)
 
-getTargIntegralTypeAtIdx(targs, i) =
+getTargAsIntegralAtIdx(targs::pcpp"clang::TemplateSpecializationType", i) =
+   ccall((:getTSTTargAsIntegralAtIdx,libcxxffi),Int64,(Ptr{Void},Csize_t),targs,i)
+
+getTargIntegralTypeAtIdx(targs::Union{rcpp"clang::TemplateArgumentList",
+                                        pcpp"clang::TemplateArgumentList"}, i) =
     QualType(ccall((:getTargIntegralTypeAtIdx,libcxxffi),Ptr{Void},(Ptr{Void},Csize_t),targs,i))
+
+getTargIntegralTypeAtIdx(targs::pcpp"clang::TemplateSpecializationType", i) =
+    QualType(ccall((:getTSTTargIntegralTypeAtIdx,libcxxffi),Ptr{Void},(Ptr{Void},Csize_t),targs,i))
 
 getTargPackAtIdxSize(targs, i) =
     ccall((:getTargPackAtIdxSize, libcxxffi), Csize_t, (Ptr{Void}, Csize_t), targs, i)

--- a/src/clangwrapper.jl
+++ b/src/clangwrapper.jl
@@ -664,6 +664,9 @@ ExitParserScope(C) = ccall((:ExitParserScope,libcxxffi),Void,(Ref{ClangCompiler}
 ActOnTypeParameterParserScope(C, Name, pos) =
     pcpp"clang::Decl"(ccall((:ActOnTypeParameterParserScope,libcxxffi),Ptr{Void},(Ref{ClangCompiler},Ptr{UInt8},Cint),C,Name,pos))
 
+ActOnNonTypeParameterParserScope(C, Name, pos) =
+    pcpp"clang::Decl"(ccall((:ActOnNonTypeParameterParserScope,libcxxffi),Ptr{Void},(Ref{ClangCompiler},Ptr{UInt8},Cint),C,Name,pos))
+
 getUnderlyingTemplateDecl(TST) =
     pcpp"clang::TemplateDecl"(ccall((:getUnderlyingTemplateDecl,libcxxffi),Ptr{Void},(Ptr{Void},),TST))
 

--- a/src/cxxstr.jl
+++ b/src/cxxstr.jl
@@ -546,11 +546,17 @@ end
     else
         ctx = Cxx.to_ctx(translation_unit(C))
     end
+    isnontypeparam(arg) = (arg <: Type && arg.parameters[1] <: Val)
     for (i,arg) in enumerate(args)
-        if arg == TypeVar || arg <: Integer
+    @show arg
+        if arg == TypeVar || arg <: Integer || isnontypeparam(arg)
             name = string(iscc ? "__juliavar" : "var",varnum)
             typename = replace(typename, string(iscc ? "__juliavar" : "__julia::var",i), name)
-            ActOnTypeParameterParserScope(C,name,varnum)
+            if isnontypeparam(arg)
+                ActOnNonTypeParameterParserScope(C,name,varnum)
+            else
+                ActOnTypeParameterParserScope(C,name,varnum)
+            end
             mapping[varnum] = :(args[$i])
             varnum += 1
         elseif arg <: Type

--- a/src/typetranslation.jl
+++ b/src/typetranslation.jl
@@ -421,8 +421,12 @@ function getTemplateParameters(cxxd,quoted = false,typeargs = Dict{Int64,Void}()
     args = Any[]
     for i = 0:(getTargsSize(targs)-1)
         kind = getTargKindAtIdx(targs,i)
+        @show kind
         if kind == KindType
             T = juliatype(getTargTypeAtIdx(targs,i),quoted,typeargs; wrapvalue = false)
+            push!(args,T)
+        elseif kind == KindExpression
+            @show T = typeargs[i]
             push!(args,T)
         elseif kind == KindIntegral
             val = getTargAsIntegralAtIdx(targs,i)


### PR DESCRIPTION
The following currently doesn't work:
```julia
cxx"""
           template<typename T, int R, int C=5>
           struct LikeEigen { T val = 5.0; };
"""
const LikeEigen{T,R} = cxxt"LikeEigen<$T,$(Val{R})>"
```

This example seems to work with the changes in this PR, but adding a calculation on the defaulted parameter (as is done in the Eigen lib) fails:

```julia
cxx"""
           template<typename T, int R, int C=5+R>
           struct LikeEigen2 { T val = 5.0; };
"""
const LikeEigen2{T,R} = cxxt"LikeEigen2<$T,$(Val{R})>"
```

This PR is mostly for reference, maybe it goes in the right direction but I don't really know what I'm doing here. It is also not urgent.